### PR TITLE
バグ修正

### DIFF
--- a/FMMain.mm
+++ b/FMMain.mm
@@ -68,8 +68,13 @@ FMMain::~FMMain() {
 }
 
 int FMMain::LoadTone(const char *tonefile) {
-	FILE *fi = fopen(tonefile, "rb");
+	FILE *fi;
+#ifdef WIN32
+	if(fopen_s(&fi,tonefile,"rb") != 0)return 1;
+#else
+	fi = fopen(tonefile, "rb");
 	if (!fi) return 1;
+#endif
 	fseek(fi, 0, SEEK_END);
 	size_t len = ftell(fi);
 	rewind(fi);

--- a/FMMain.mm
+++ b/FMMain.mm
@@ -69,8 +69,8 @@ FMMain::~FMMain() {
 
 int FMMain::LoadTone(const char *tonefile) {
 	FILE *fi;
-#ifdef WIN32
-	if(fopen_s(&fi,tonefile,"rb") != 0)return 1;
+#ifdef #if defined(WIN32) && _MSC_VER >= 1400
+	if(fopen_s(&fi, tonefile, "rb") != 0) return 1;
 #else
 	fi = fopen(tonefile, "rb");
 	if (!fi) return 1;

--- a/Midi.mm
+++ b/Midi.mm
@@ -82,8 +82,12 @@ int Midi::get4() { // cannot read value -1
 int Midi::Prepare(const char *path) {
 	if (fi) fclose(fi);
 	Clear();
+#ifdef WIN32
+	if(fopen_s(&fi,path,"rb") != 0)return 1;
+#else
 	fi = fopen(path, "rb");
 	if (!fi) return 1;
+#endif
 	if (get4() != 'MThd') return 1;
 	if (get4() != 6) return 1;
 	int c = get2();

--- a/Midi.mm
+++ b/Midi.mm
@@ -82,8 +82,8 @@ int Midi::get4() { // cannot read value -1
 int Midi::Prepare(const char *path) {
 	if (fi) fclose(fi);
 	Clear();
-#ifdef WIN32
-	if(fopen_s(&fi,path,"rb") != 0)return 1;
+#if defined(WIN32) && _MSC_VER >= 1400
+	if(fopen_s(&fi, path, "rb") != 0) return 1;
 #else
 	fi = fopen(path, "rb");
 	if (!fi) return 1;

--- a/Operator8.h
+++ b/Operator8.h
@@ -100,7 +100,7 @@ class Operator8 {
 		u32 GetDelta(u8 note, s16 bend) { // note:0-254
 			u16 v = (note << 7) + bend + det;
 			u16 index = v >> 7;
-			if (index > 510) index = 510;
+			if (index > 254) index = 254;
 			v &= 0x7f;
 			u32 d = ((128 - v) * deltatable[index] + v * deltatable[index + 1]) >> 7;
 			return mul * d >> 9;

--- a/main.mm
+++ b/main.mm
@@ -48,7 +48,11 @@ int main(int argc, char *const *argv) {
 	AudioSetup(FMMain::Callback);
 	gFMMain = new FMMain;
 	char s[16];
+#if defined(WIN32) && _MSC_VER >= 1400
+	sprintf_s(s, "tone%d.bin", t % 10);
+#else 
 	sprintf(s, "tone%d.bin", t % 10);
+#endif
 	if (gFMMain->LoadTone(s)) {
 		fprintf(stderr, "%s not found.\n", s);
 		return 1;


### PR DESCRIPTION
範囲チェックの修正とWindows向けの修正を行いました。

Windows(VisualStudio)ではfopenを使用するとエラーが出てコンパイルができない(_CRT_SECURE_NO_WARNINGSを定義すれば可能)ため、安全な関数(fopen_s)を用いて読み込みを行うようにしています。

VisualStudio 2022での動作を確認しました。