### PR TITLE
Windows用types.hの修正

### DIFF
--- a/win/types.h
+++ b/win/types.h
@@ -8,6 +8,7 @@ typedef signed char s8;
 typedef short s16;
 typedef int s32;
 typedef float f32;
+typedef long long s64;
 
 #include <windows.h>
 #include <signal.h>


### PR DESCRIPTION
## 概要
Windows用のtypes.hの定義が更新されていなかったので修正しました．

## 変更内容
s64の定義を`win/types.h`に追記．

## 動作確認
Windows 11(x64) + Visual Studio 2022でコンパイルが通ることを確認しました．